### PR TITLE
feat: add getWalletCount  RPC API

### DIFF
--- a/rpc-client-api/src/config.rs
+++ b/rpc-client-api/src/config.rs
@@ -177,6 +177,15 @@ pub struct RpcProgramAccountsConfig {
     pub with_context: Option<bool>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcWalletCountConfig {
+    pub filters: Option<Vec<RpcFilterType>>,
+    #[serde(flatten)]
+    pub account_config: RpcAccountInfoConfig,
+    pub with_context: Option<bool>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum RpcTransactionLogsFilter {


### PR DESCRIPTION
Solana's getProgramAccounts RPC method is designed to return all accounts owned by a specified program. While this can be very useful for certain use cases (such as getting a complete overview of a program's state), it does result in a large amount of data being returned, especially if the program owns a large number of accounts. This can have a negative impact on server-side system and client performance, especially in cases of network congestion or limited resources. When only the number of accounts under a specific program needs to be counted, using getProgramAccounts will return all account detail data, which will greatly affect the performance of the server-side system and the client. Therefore, a new getWalletCount interface is added to meet the demand of simply counting the number of accounts.

Here are some of the key points:

getProgramAccounts returns all accounts owned by a specified program.
This can be useful for getting a complete overview of a program's state.
However, it can also result in a large amount of data being returned.
This can have a negative impact on performance, especially for programs with many accounts.
The new getWalletCount interface can be used to count the number of accounts owned by a program without returning all account detail data.
This can improve performance, especially for programs with many accounts.