### PR TITLE
chore: Add state module for migrated accounts

### DIFF
--- a/programs/sonic-account-migrater/src/processor.rs
+++ b/programs/sonic-account-migrater/src/processor.rs
@@ -1,14 +1,12 @@
 use {
-    solana_program_runtime::{declare_process_instruction, ic_msg, invoke_context::InvokeContext},
-    solana_sdk::{
+    serde::Serialize, solana_program_runtime::{declare_process_instruction, ic_msg, invoke_context::InvokeContext}, solana_sdk::{
         instruction::InstructionError, program_utils::limited_deserialize, pubkey::Pubkey, sonic_account_migrater::{
-            instruction::ProgramInstruction,
-            program::check_id,
-        }
-    },
+            instruction::ProgramInstruction, migrated_accounts, program, state::{MigratedAccount, MigratedAccountsState}
+        }, transaction_context::BorrowedAccount
+    }, std::{borrow::Borrow, collections::{HashMap, HashSet}}
 };
 
-pub const DEFAULT_COMPUTE_UNITS: u64 = 750;
+pub const DEFAULT_COMPUTE_UNITS: u64 = 1500;
 
 // /// The maximum number of addresses that a lookup table can hold
 // pub const MAX_ADDRESSES: usize = 256;
@@ -18,12 +16,16 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();
     match limited_deserialize(instruction_data)? {
-        ProgramInstruction::MigrateRemoteAccounts => Processor::migrate_remote_accounts(invoke_context),
-        ProgramInstruction::DeactivateRemoteAccounts => Processor::deactivate_remote_accounts(invoke_context),
+        ProgramInstruction::MigrateRemoteAccounts{
+            addresses,
+        } => Processor::migrate_remote_accounts(invoke_context, addresses),
+        ProgramInstruction::DeactivateRemoteAccounts{
+            addresses,
+        } => Processor::deactivate_remote_accounts(invoke_context, addresses),
         ProgramInstruction::MigrateSourceAccounts{
             node_id,
-            refresh,
-        } => Processor::migrate_source_accounts(invoke_context, node_id, refresh),
+            addresses,
+        } => Processor::migrate_source_accounts(invoke_context, node_id, addresses),
     }
 });
 
@@ -31,7 +33,13 @@ pub struct Processor;
 impl Processor {
     fn migrate_remote_accounts(
         invoke_context: &mut InvokeContext,
+        addresses: Vec<Pubkey>,
     ) -> Result<(), InstructionError> {
+        if addresses.is_empty() {
+            ic_msg!(invoke_context, "Must provide at least one address");
+            return Err(InstructionError::InvalidInstructionData);
+        }
+
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
 
@@ -41,18 +49,59 @@ impl Processor {
             return Err(InstructionError::NotEnoughAccountKeys);
         }
 
-        let mut addresses_len = 0;
+        let mut has_data_acount = false;
+        let mut data_account_index: u16 = 0;
         for i in 0..n {
             let account = instruction_context.try_borrow_instruction_account(transaction_context, i)?;
-            let key = *account.get_key();
-            if !account.is_signer() && !account.is_writable() && !check_id(&key) {
-                ic_msg!(invoke_context, "Account {:?} is migrated from remote.", key);
-                addresses_len += 1;
+            if migrated_accounts::check_id(account.get_key()) && !account.is_signer() && account.is_writable() {
+                ic_msg!(invoke_context, "Account {:?} is not signer or writable.", account.get_key());
+                has_data_acount = true;
+                data_account_index = i;
             }
         }
 
+        if !has_data_acount {
+            ic_msg!(invoke_context, "No valid accounts provided");
+            return Err(InstructionError::NotEnoughAccountKeys);
+        }
+
+        let mut accouts: HashMap<Pubkey, MigratedAccount> = HashMap::new();
+        let mut data_account = instruction_context.try_borrow_instruction_account(transaction_context, data_account_index)?;
+        if let MigratedAccountsState::MigratedAccounts(accounts2) = data_account.get_state()? {
+            accounts2.iter().for_each(|account| {
+                accouts.insert(account.address, account.clone());
+            });
+        } else {
+            ic_msg!(invoke_context, "data account is not initialized."); 
+        }
+
         let clock = invoke_context.get_sysvar_cache().get_clock()?;
-        ic_msg!(invoke_context, "{} Remote Accounts are migrated at slot {}.", addresses_len, clock.slot);
+        let slot = clock.slot;
+
+        for address in addresses.iter() {
+            ic_msg!(invoke_context, "Account {:?} is migrated at slot {:?} from remote.", address, slot);
+            accouts.insert(address.clone(), MigratedAccount {
+                address: address.clone(),
+                source: None,
+                slot: slot,
+            });
+        }
+
+        let state = MigratedAccountsState::MigratedAccounts(accouts.values().cloned().collect::<Vec<MigratedAccount>>());
+        let serialized_data = bincode::serialize(&state).map_err(|_| InstructionError::GenericError)?;
+        data_account.set_data_from_slice(&serialized_data)?;
+
+        // let serialized_size =
+        //     bincode::serialized_size(&state).map_err(|_| InstructionError::GenericError)?;
+        
+        // if serialized_size > data_account.capacity() as u64 {
+        //     data_account.can_data_be_resized(serialized_size)
+        //     return Err(InstructionError::AccountDataTooSmall);
+        // }
+        // data_account.set_state(&state)?;
+
+        // let clock = invoke_context.get_sysvar_cache().get_clock()?;
+        ic_msg!(invoke_context, "{} Remote Accounts are migrated at slot {}.", addresses.len(), clock.slot);
 
         Ok(())
     }
@@ -60,8 +109,13 @@ impl Processor {
     fn migrate_source_accounts(
         invoke_context: &mut InvokeContext,
         node_id: Pubkey,
-        refresh: bool,
+        addresses: Vec<Pubkey>,
     ) -> Result<(), InstructionError> {
+        if addresses.is_empty() {
+            ic_msg!(invoke_context, "Must provide at least one address");
+            return Err(InstructionError::InvalidInstructionData);
+        }
+
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
 
@@ -71,44 +125,111 @@ impl Processor {
             return Err(InstructionError::NotEnoughAccountKeys);
         }
 
-        let mut addresses_len = 0;
+        let mut has_data_acount = false;
+        let mut data_account_index: u16 = 0;
         for i in 0..n {
             let account = instruction_context.try_borrow_instruction_account(transaction_context, i)?;
-            let key = *account.get_key();
-            if !account.is_signer() && !account.is_writable() && !check_id(&key) {
-                ic_msg!(invoke_context, "Account {:?} is migrated from {}.", key, node_id);
-                addresses_len += 1;
+            if migrated_accounts::check_id(account.get_key()) && !account.is_signer() && account.is_writable() {
+                ic_msg!(invoke_context, "Data account is {:?}.", account.get_key());
+                has_data_acount = true;
+                data_account_index = i;
             }
         }
 
+        if !has_data_acount {
+            ic_msg!(invoke_context, "No valid data account provided");
+            return Err(InstructionError::NotEnoughAccountKeys);
+        }
+
+        let mut accouts: HashMap<Pubkey, MigratedAccount> = HashMap::new();
+        let mut data_account = instruction_context.try_borrow_instruction_account(transaction_context, data_account_index)?;
+        if let MigratedAccountsState::MigratedAccounts(accounts2) = data_account.get_state()? {
+            accounts2.iter().for_each(|account: &MigratedAccount| {
+                ic_msg!(invoke_context, "Accout migrated: {:?} at slot {:?}.", account.address, account.slot); 
+                accouts.insert(account.address, account.clone());
+            });
+        } else {
+            ic_msg!(invoke_context, "Data account is not initialized."); 
+        }
+        
         let clock = invoke_context.get_sysvar_cache().get_clock()?;
-        ic_msg!(invoke_context, "{} Remote Accounts are migrated from {} at slot {}, refresh: {}.", addresses_len, node_id, clock.slot, refresh);
+        let slot = clock.slot;
+
+        for address in addresses.iter() {
+            ic_msg!(invoke_context, "Account {:?} is migrated at slot {:?} from {:?}.", address, slot, node_id);
+            accouts.insert(address.clone(), MigratedAccount {
+                address: address.clone(),
+                source: Some(node_id),
+                slot,
+            });
+        }
+
+        let state = MigratedAccountsState::MigratedAccounts(accouts.values().cloned().collect::<Vec<MigratedAccount>>());
+        let serialized_data = bincode::serialize(&state).map_err(|_| InstructionError::GenericError)?;
+        data_account.set_data_from_slice(&serialized_data)?;
+        // data_account.set_state(&MigratedAccountsState::MigratedAccounts(accouts.values().cloned().collect::<Vec<MigratedAccount>>()))?;
+
+        // let clock = invoke_context.get_sysvar_cache().get_clock()?;
+        ic_msg!(invoke_context, "{} Remote Accounts are migrated from {} at slot {}.", addresses.len(), node_id, clock.slot);
 
         Ok(())
     }
 
-    fn deactivate_remote_accounts(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+    fn deactivate_remote_accounts(
+        invoke_context: &mut InvokeContext,
+        addresses: Vec<Pubkey>,
+    ) -> Result<(), InstructionError> {
+        
+        if addresses.is_empty() {
+            ic_msg!(invoke_context, "Must provide at least one address");
+            return Err(InstructionError::InvalidInstructionData);
+        }
+
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
-        
+
         let n = instruction_context.get_number_of_instruction_accounts();
         if n < 1 {
             ic_msg!(invoke_context, "No accounts provided");
             return Err(InstructionError::NotEnoughAccountKeys);
         }
 
-        let mut addresses_len = 0;
+        let mut has_data_acount = false;
+        let mut data_account_index: u16 = 0;
         for i in 0..n {
             let account = instruction_context.try_borrow_instruction_account(transaction_context, i)?;
-            let key = *account.get_key();
-            if !account.is_signer() && !account.is_writable() && !check_id(&key) {
-                ic_msg!(invoke_context, "Account {:?} is deactivated in cache.", key);
-                addresses_len += 1;
+            if migrated_accounts::check_id(account.get_key()) && !account.is_signer() && account.is_writable() {
+                // ic_msg!(invoke_context, "Account {:?} is not signer or writable.", account.get_key());
+                has_data_acount = true;
+                data_account_index = i;
             }
         }
 
+        if !has_data_acount {
+            ic_msg!(invoke_context, "No valid data account provided");
+            return Err(InstructionError::NotEnoughAccountKeys);
+        }
+
+        let mut accouts: HashMap<Pubkey, MigratedAccount> = HashMap::new();
+        let mut data_account = instruction_context.try_borrow_instruction_account(transaction_context, data_account_index)?;
+        if let MigratedAccountsState::MigratedAccounts(accounts2) = data_account.get_state()? {
+            accounts2.iter().for_each(|account| {
+                accouts.insert(account.address, account.clone());
+            });
+        } else {
+            ic_msg!(invoke_context, "data account is not initialized."); 
+            return Err(InstructionError::InvalidAccountData);
+        }
+
+        for address in addresses.iter() {
+            ic_msg!(invoke_context, "Account {:?} is deactivated in cache.", address);
+            accouts.remove(address);
+        }
+        
+        data_account.set_state(&MigratedAccountsState::MigratedAccounts(accouts.values().cloned().collect::<Vec<MigratedAccount>>()))?;
+
         let clock = invoke_context.get_sysvar_cache().get_clock()?;
-        ic_msg!(invoke_context, "{} Remote Accounts are already deactivated at slot {}.", addresses_len, clock.slot);
+        ic_msg!(invoke_context, "{} Remote Accounts are already deactivated at slot {}.", addresses.len(), clock.slot);
 
         Ok(())
     }

--- a/sdk/program/src/sonic_account_migrater/instruction.rs
+++ b/sdk/program/src/sonic_account_migrater/instruction.rs
@@ -1,63 +1,21 @@
 use {
-    crate::{
-        sonic_account_migrater::program::id,
-        instruction::{AccountMeta, Instruction},
-        pubkey::Pubkey,
-        system_program,
-    },
+    crate::pubkey::Pubkey,
     serde::{Deserialize, Serialize},
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum ProgramInstruction {
     ///Migrate remote accounts to local accounts cache
-    MigrateRemoteAccounts,
-    ///Deactivate remote accounts in local accounts cache
-    DeactivateRemoteAccounts,
-    ///Migrate remote accounts from source to local accounts cache
-    MigrateSourceAccounts{
-        node_id: Pubkey,
-        refresh: bool,
+    MigrateRemoteAccounts {
+        addresses: Vec<Pubkey>,
     },
-}
-
-/// Constructs an instruction which migrate remote accounts to local accounts cache.
-pub fn migrate_remote_accounts(
-    payer_address: Pubkey,
-    addresses: Vec<Pubkey>,
-) -> Instruction {
-    let mut accounts = vec![
-        AccountMeta::new_readonly(payer_address, true),
-        AccountMeta::new_readonly(system_program::id(), false),
-    ];
-
-    for address in addresses {
-        accounts.push(AccountMeta::new_readonly(address, false));
-    }
-
-    Instruction::new_with_bincode(
-        id(),
-        &ProgramInstruction::MigrateRemoteAccounts, // { addresses },
-        accounts,
-    )
-}
-
-/// Constructs an instruction that deactivates remote accounts in local accounts cache.
-pub fn deactivate_remote_accounts(
-    payer_address: Pubkey,
-    addresses: Vec<Pubkey>,
-) -> Instruction {
-    let mut accounts = vec![
-        AccountMeta::new_readonly(payer_address, true),
-        AccountMeta::new_readonly(system_program::id(), false),
-    ];
-
-    for address in addresses {
-        accounts.push(AccountMeta::new_readonly(address, false));
-    }
-    Instruction::new_with_bincode(
-        id(),
-        &ProgramInstruction::DeactivateRemoteAccounts,
-        accounts,
-    )
+    ///Deactivate remote accounts in local accounts cache
+    DeactivateRemoteAccounts {
+        addresses: Vec<Pubkey>,
+    },
+    ///Migrate remote accounts from source to local accounts cache
+    MigrateSourceAccounts {
+        node_id: Pubkey,
+        addresses: Vec<Pubkey>,
+    },
 }

--- a/sdk/program/src/sonic_account_migrater/mod.rs
+++ b/sdk/program/src/sonic_account_migrater/mod.rs
@@ -3,10 +3,13 @@
 //! [np]: 
 
 pub mod instruction;
+pub mod state;
 
 
 pub mod program {
     crate::declare_id!("SonicAccountMigrater11111111111111111111111");
 }
 
-
+pub mod migrated_accounts {
+    crate::declare_id!("SonicMigratedAccounts1111111111111111111112");
+}

--- a/sdk/program/src/sonic_account_migrater/state.rs
+++ b/sdk/program/src/sonic_account_migrater/state.rs
@@ -1,0 +1,22 @@
+use {
+    serde::{Deserialize, Serialize},
+    solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample},
+    solana_program::pubkey::Pubkey,
+};
+
+/// Program account states
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, AbiExample, AbiEnumVisitor)]
+#[allow(clippy::large_enum_variant)]
+pub enum MigratedAccountsState {
+    /// Account is not initialized.
+    Uninitialized,
+    /// Initialized `MigratedAccounts` account.
+    MigratedAccounts(Vec<MigratedAccount>),
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, AbiExample, AbiEnumVisitor)]
+pub struct MigratedAccount {
+    pub address: Pubkey,
+    pub source: Option<Pubkey>, 
+    pub slot: u64,
+}


### PR DESCRIPTION
Added a new module called `state` in the `sonic_account_migrater` directory. This module contains the definition of the `MigratedAccountsState` enum and the `MigratedAccount` struct. These types represent the different states of the program accounts and the details of each migrated account.

Refactor the `instruction` module

Refactored the `instruction` module in the `sonic_account_migrater` directory. Removed the `migrate_remote_accounts` and `deactivate_remote_accounts` functions and replaced them with new variants of the `ProgramInstruction` enum. The new variants, `MigrateRemoteAccounts` and `DeactivateRemoteAccounts`, now include a vector of addresses as a parameter.

Update `mod.rs` file

Added a new module called `migrated_accounts` in the `sonic_account_migrater` directory. This module is used to declare the ID for the `MigratedAccounts` program account.

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
