### PR TITLE
Refactor account cache and remote loader

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -1,6 +1,6 @@
 use {
     crate::{accounts_db::AccountsDb, accounts_hash::AccountHash}, dashmap::DashMap, seqlock::SeqLock, solana_sdk::{
-        account::{Account, AccountSharedData, ReadableAccount},
+        account::{AccountSharedData, ReadableAccount},
         clock::Slot,
         pubkey::Pubkey,
     }, sonic_hypergrid::remote_loader::RemoteAccountLoader, std::{

--- a/hypergrid/src/config.rs
+++ b/hypergrid/src/config.rs
@@ -31,7 +31,7 @@ impl Default for Config {
         let keypair_base58 = "5gA6JTpFziXu7py2j63arRUq1H29p6pcPMB74LaNuzcSqULPD6s1SZUS3UMPvFEE9oXmt1kk6ez3C6piTc3bwpJ6".to_string();
         let baselayer_rpc_url = "https://api.devnet.solana.com".to_string();
         let sonic_program_id ="4WTUyXNcf6QCEj76b3aRDLPewkPGkXFZkkyf3A3vua1z".to_string();
-        let hssn_rpc_url: String = "http://localhost:1317".to_string();
+        let hssn_rpc_url: String = "https://api.hypergrid.dev".to_string();
         let accounts_path: String = "hypergrid/accounts".to_string();
 
         Self {

--- a/hypergrid/src/cosmos.rs
+++ b/hypergrid/src/cosmos.rs
@@ -28,6 +28,11 @@ pub fn run_load_solana_account(pub_key: &str, version:  &str, source: &str, upda
         _path.extend([COSMOS_HOME, COSMOS_APP]);
         _path.to_str().unwrap().to_string()
     };
+
+    let app_path = std::path::Path::new(&cosmos_app_path);
+    if !app_path.exists() {
+        warn!("{} does not exist.", cosmos_app_path);
+    }
     
     //format the command string
     let cmd_str: String;

--- a/hypergrid/src/remote_loader.rs
+++ b/hypergrid/src/remote_loader.rs
@@ -220,6 +220,13 @@ impl RemoteAccountLoader {
 
     fn save_account_to_local_file(&self, slot: Slot, pubkey: &Pubkey, source: Option<Pubkey>, account: AccountSharedData) {
         let path = format!("{}/{:?}_{:?}_{:?}.json", self.config.accounts_path, pubkey, source.unwrap_or_default(), slot);
+
+        //make sure the directory exists
+        let dir = std::path::Path::new(&path).parent().unwrap();
+        if !dir.exists() {
+            std::fs::create_dir_all(dir).unwrap_or_default();
+        }
+
         println!("save_account_to_local_file: {}\n", path);
         let file = File::create(path.clone());
         match file {
@@ -274,7 +281,7 @@ impl RemoteAccountLoader {
                 if node.value().role == 2 || node.value().role == 3 || node.value().role == 4 {
                     rpc_url = node.value().rpc.clone();
                 } else {
-                    info!("load_account_via_rpc: invalid source role: {}", node.value().role);
+                    info!("load_account_via_rpc: invalid source role: {:?}, {:?}, {:?}", node.value().name, node.value().pubkey, node.value().role);
                     return None;
                 }
             }


### PR DESCRIPTION
- Remove unused import of Account from accounts_cache.rs
- Update hssn_rpc_url in config.rs to use the hypergrid API
- Add error handling for non-existent cosmos app path in cosmos.rs
- Create directory if it doesn't exist before saving account to local file in remote_loader.rs
- Improve logging message for invalid source role in remote_loader.rs

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
