### PR TITLE
refactor: Update keypair_base58 to keypair_file in Config struct

### DIFF
--- a/hypergrid/src/config.rs
+++ b/hypergrid/src/config.rs
@@ -21,13 +21,13 @@ where
 pub struct Config {
     pub baselayer_rpc_url: String,
     pub hssn_rpc_url: String,
-    pub keypair_base58: String,
+    pub keypair_file: String,
     pub sonic_program_id: String,
 }
 
 impl Default for Config {
     fn default() -> Self {
-        let keypair_base58 = "5gA6JTpFziXu7py2j63arRUq1H29p6pcPMB74LaNuzcSqULPD6s1SZUS3UMPvFEE9oXmt1kk6ez3C6piTc3bwpJ6".to_string();
+        let keypair_file = "~/.config/solana/id.json".to_string();
         let baselayer_rpc_url = "https://api.devnet.solana.com".to_string();
         let sonic_program_id ="4WTUyXNcf6QCEj76b3aRDLPewkPGkXFZkkyf3A3vua1z".to_string();
         let hssn_rpc_url: String = "http://localhost:1317".to_string();
@@ -35,7 +35,7 @@ impl Default for Config {
         Self {
             baselayer_rpc_url,
             hssn_rpc_url,
-            keypair_base58,
+            keypair_file,
             sonic_program_id,
         }
     }

--- a/hypergrid/src/remote_loader.rs
+++ b/hypergrid/src/remote_loader.rs
@@ -1,19 +1,10 @@
 use {
-    crate::{config::Config, cosmos}, base64::{self, Engine}, core::fmt, dashmap::DashMap, 
-    serde_derive::{Deserialize, Serialize}, sha2::{Digest, Sha256}, solana_client::rpc_client::RpcClient, solana_measure::measure::Measure, solana_sdk::{
-        account::{AccountSharedData, ReadableAccount, WritableAccount}, 
-        account_utils::StateMut, 
-        bpf_loader_upgradeable::{self, UpgradeableLoaderState}, 
-        commitment_config::CommitmentConfig, 
-        instruction::{AccountMeta, Instruction}, 
-        pubkey::Pubkey, 
-        signature::{Keypair, Signature, Signer}, 
-        transaction::Transaction
+    crate::{config::Config, cosmos}, base64::{self, Engine}, core::fmt, dashmap::DashMap, log::*, serde_derive::{Deserialize, Serialize}, sha2::{Digest, Sha256}, solana_client::rpc_client::RpcClient, solana_measure::measure::Measure, solana_sdk::{
+        account::{AccountSharedData, ReadableAccount, WritableAccount}, account_utils::StateMut, bpf_loader_upgradeable::{self, UpgradeableLoaderState}, commitment_config::CommitmentConfig, instruction::{AccountMeta, Instruction}, pubkey::Pubkey, signature::{Keypair, Signature, Signer}, signer::EncodableKey, transaction::Transaction
     }, std::{
         option_env, str::FromStr, thread,
         time::{Duration, Instant},
-    }, zstd,
-    log::*,
+    }, zstd
 };
 
 
@@ -438,7 +429,13 @@ impl RemoteAccountLoader {
     /// Send a transaction to the base layer to update the status of the account.
     pub fn send_status_to_baselayer(&self, program_id: &Pubkey, account: &Pubkey, value:u64) -> Option<Signature> {
         let mut time = Measure::start("load_account_from_remote");
-        let payer = Keypair::from_base58_string(&self.config.keypair_base58);
+        let keypair = Keypair::read_from_file(&self.config.keypair_file);
+        if let Err(e) = keypair {
+            error!("send_transaction_to_baselayer: failed to read keypair: {:?}", e);
+            return None;
+        }
+
+        let payer = keypair.unwrap();
         // let program_id = Pubkey::from_str(SONIC_PROGRAM_ID).unwrap();
 
         let setlocker_data = SetLockerInstruction {


### PR DESCRIPTION
This commit updates the `Config` struct in `config.rs` to replace the `keypair_base58` field with the `keypair_file` field. The `keypair_file` field now stores the path to the keypair file instead of the base58-encoded keypair string. This change improves the portability and security of the application.

The `keypair_base58` field is removed, and the `keypair_file` field is added with the default value of "~/.config/solana/id.json".

This commit also updates the `send_status_to_baselayer` method in `remote_loader.rs` to read the keypair from the file specified in the `Config` struct.

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
